### PR TITLE
add files showing typedoc bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 docs
+build
+.DS_Store
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc-repros",
   "dependencies": {
-    "typedoc": "latest",
+    "typedoc": "^0.25.4",
     "typescript": "latest"
   }
 }

--- a/src/BugAbstractSubject.ts
+++ b/src/BugAbstractSubject.ts
@@ -1,0 +1,14 @@
+/** The base class. Has method {@link getAbstractSubject} */
+export class BugAbstractSubject {
+
+/**
+*/
+constructor() {
+};
+
+/** returns the string 'AbstractSubject' */
+getAbstractSubject(): string {
+  return 'AbstractSubject';
+};
+
+} // end BugAbstractSubject class

--- a/src/BugContactSim.ts
+++ b/src/BugContactSim.ts
@@ -1,0 +1,16 @@
+import { BugImpulseSim } from './BugImpulseSim.js';
+
+/** The fourth class in hierarchy. 
+Inherits the method {@link getImpulseSim} aka {@link BugImpulseSim.getImpulseSim}.
+
+Inherits method {@link getRigidBodySim} aka {@link BugRigidBodySim.BugRigidBodySim.getRigidBodySim}
+*/
+export class BugContactSim extends BugImpulseSim {
+
+/**
+*/
+constructor() {
+  super();
+};
+
+} // end class

--- a/src/BugImpulseSim.ts
+++ b/src/BugImpulseSim.ts
@@ -1,0 +1,26 @@
+import { BugRigidBodySim } from './BugRigidBodySim.js';
+
+/** The third class in hierarchy.
+
+Adds method {@link getImpulseSim} aka {@link BugImpulseSim.getImpulseSim}.
+
+Inherits method {@link getRigidBodySim} aka {@link BugRigidBodySim.getRigidBodySim}
+
+Inherits method {@link getAbstractSubject}
+
+this causes error with typedoc:  \@link BugContactSim.getImpulseSim
+*/
+export class BugImpulseSim extends BugRigidBodySim {
+/**
+*/
+constructor() {
+  super();
+};
+
+/** returns the string 'ImpulseSim' */
+getImpulseSim(): string {
+  return 'ImpulseSim';
+};
+
+} // end class
+

--- a/src/BugRigidBodySim.ts
+++ b/src/BugRigidBodySim.ts
@@ -1,0 +1,22 @@
+import { BugAbstractSubject } from './BugAbstractSubject.js';
+
+/** The second class in hierarchy.
+
+Adds method {@link getRigidBodySim} aka {@link BugRigidBodySim.getRigidBodySim}
+
+Inherits method {@link getAbstractSubject}
+*/
+export class BugRigidBodySim extends BugAbstractSubject {
+
+/**
+*/
+constructor() {
+  super();
+};
+
+/** returns the string 'RigidBodySim' */
+getRigidBodySim(): string {
+  return 'RigidBodySim';
+};
+
+} // end BugRigidBodySim class

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-        "strict": true
+        "strict": true,
+        "outDir": "build",
     },
-    "include": ["src"]
+    "include": ["src/**/*"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://typedoc.org/schema.json",
-    "entryPoints": ["src/index.ts"],
+    "entryPointStrategy": "expand",
+    "entryPoints": ["./src"],
 
     "treatWarningsAsErrors": true,
     "out": "docs",


### PR DESCRIPTION
These files show a possible typedoc bug, I'm creating an issue titled "link references go to incorrect class/interface" for this.

Basically, the `{@link methodName}` markdown is generating links that go to a sub-class instead of the class where the method is defined.