### PR TITLE
Reproducing bug #2811

### DIFF
--- a/src/index-debug.ts
+++ b/src/index-debug.ts
@@ -1,0 +1,6 @@
+/**
+ * @module
+ * @ignore
+ */
+
+export * from "./index";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,1 @@
-/**
- * Some code reproducing a bug.
- */
-export const bug = 123;
+export { settings } from "./settings";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,3 @@
+export const settings = {
+  someSetting: false,
+};

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,8 +1,8 @@
 {
-    "$schema": "https://typedoc.org/schema.json",
-    "entryPoints": ["src/index.ts"],
-
-    "treatWarningsAsErrors": true,
-    "out": "docs",
-    "json": "docs/docs.json"
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/"],
+  "entryPointStrategy": "expand",
+  "treatWarningsAsErrors": true,
+  "out": "docs",
+  "json": "docs/docs.json"
 }


### PR DESCRIPTION
Requires entryPointStrategy expand and the following import structure:

file 1 exports something
file 2 re-exports this
file 3 re-exports everything from file 2 but is marked as "@ignore"

Result:  `settings` does NOT show up in `index`

![Screenshot 2024-12-16 175509](https://github.com/user-attachments/assets/95585be2-3083-4a91-8b6c-5dd3e784906f)

If I remove `@ignore` from `index-debug.ts`, then `settings` correctly shows up in `index`:

![Screenshot 2024-12-16 175446](https://github.com/user-attachments/assets/5675b2e6-082f-4f25-98d0-9be922c6a25d)
