### PR TITLE
Reproduce `@linkcode` bug introduced with TypeDoc v0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typedoc-repros",
   "dependencies": {
-    "typedoc": "latest",
-    "typescript": "latest"
+    "typedoc": "0.28.2",
+    "typescript": "5.8.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,24 @@
 /**
- * Some code reproducing a bug.
+ * This is some class.
  */
-export const bug = 123;
+export class SomeClass {
+
+	/**
+	 * Creates an instance of {@linkcode SomeClass}.
+	 *
+	 * “SomeClass” in the description above has a `@linkcode` tag and
+	 * should:
+	 * 1. Link to `SomeClass` (like in the “Returns” section below).
+	 * 2. Be rendered as inline code.
+	 *
+	 * [See](https://typedoc.org/documents/Tags.__link_.html#jsdoc-compatibility):
+	 * > TypeDoc will also recognize the `@linkplain` and `@linkcode`
+	 * > JSDoc tags and resolve them with the same method as other
+	 * > links.
+	 *
+	 * This is working with TypeDoc v0.27.9, but fails to produce the
+	 * same expected output starting with v0.28.0.
+	 */
+	constructor() { }
+
+}


### PR DESCRIPTION
“SomeClass” in the description for `constructor` should:
1. Link to `SomeClass`.
2. Be rendered as inline code.

```typescript
export SomeClass {

    /**
     * Creates an instance of {@linkcode SomeClass}.
     */
    constructor() { }

}
```

This is working with TypeDoc v0.27.9, but fails to produce the same expected output starting with v0.28.0.